### PR TITLE
Disable sending traces to otlp

### DIFF
--- a/base/backend/backend.yaml
+++ b/base/backend/backend.yaml
@@ -69,6 +69,8 @@ spec:
               value: grpc
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://otlp.telemetry:4317
+            - name: OTEL_TRACES_EXPORTER
+              value: none
           ports:
             - containerPort: 8080
               name: contestant

--- a/base/batch.yaml
+++ b/base/batch.yaml
@@ -52,6 +52,8 @@ spec:
               value: grpc
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://otlp.telemetry:4317
+            - name: OTEL_TRACES_EXPORTER
+              value: none
           volumeMounts:
             - mountPath: /run/ictstore-secrets
               name: ictscore-secrets


### PR DESCRIPTION
traces が受ける側に設定されてなくてエラーになるので、送信をとめるようにします。