### PR TITLE
add contest.ictsc.net

### DIFF
--- a/prod/contestant-httproute-patch.yaml
+++ b/prod/contestant-httproute-patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: scoreserver-contestant
+spec:
+  hostnames:
+    - contest.ictsc.net

--- a/prod/kustomization.yaml
+++ b/prod/kustomization.yaml
@@ -7,6 +7,9 @@ resources:
 components:
   - ../components
 
+patches:
+  - path: contestant-httproute-patch.yaml
+
 configMapGenerator:
   - name: scoreserver-backend-config
     behavior: merge


### PR DESCRIPTION
contest.ictsc.net で本番環境のスコアサーバーを認証なしで提供します